### PR TITLE
Allow Pages Deploy Script to be Triggered Manually via GitHub

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,9 +1,10 @@
 # Simple workflow for deploying static content to GitHub Pages
-name: Deploy static content to Pages
+name: Deploy to Pages Custom Action
 
 on:
   push:
     branches: ['main']
+  worflow_dispatch:
 
 
 permissions:


### PR DESCRIPTION
Allows the GitHub Pages deploy action to be triggered manually under the Actions page in GitHub.

* Update pages.yml config to support manual triggering
* Update pages deploy script name